### PR TITLE
chore: fix CI  workflow branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [$default-branch]
+    branches: ["main"]
   pull_request:
-    branches: [$default-branch]
+    branches: ["main"]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
$default-branch only works for workflow templates but not an actual workflow