### PR TITLE
fix: fix typescript module resolution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [19.x]
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "@types/tmi.js": "^1.8.2",
         "gh-pages": "^3.2.3",
         "html-webpack-plugin": "^5.5.0",
-        "ts-loader": "^9.2.6",
-        "typescript": "^4.5.5",
+        "ts-loader": "^9.4.2",
+        "typescript": "^4.9.5",
         "webpack": "^5.67.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.7.3"
@@ -4733,9 +4733,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-      "integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
+      "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -4771,9 +4771,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8878,9 +8878,9 @@
       }
     },
     "ts-loader": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-      "integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
+      "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -8906,9 +8906,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.1",
-        "@types/react": "^17.0.38",
-        "@types/react-dom": "^17.0.11",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-jss": "^10.9.0",
@@ -20,6 +18,9 @@
         "tmi.js": "^1.8.5"
       },
       "devDependencies": {
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.10",
+        "@types/react-redux": "^7.1.25",
         "@types/tmi.js": "^1.8.2",
         "gh-pages": "^3.2.3",
         "html-webpack-plugin": "^5.5.0",
@@ -326,9 +327,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "18.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -336,11 +337,24 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
-      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.25",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
+      "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/retry": {
@@ -5461,9 +5475,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "18.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5471,11 +5485,24 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
-      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.25",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
+      "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/retry": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@types/tmi.js": "^1.8.2",
     "gh-pages": "^3.2.3",
     "html-webpack-plugin": "^5.5.0",
-    "ts-loader": "^9.2.6",
-    "typescript": "^4.5.5",
+    "ts-loader": "^9.4.2",
+    "typescript": "^4.9.5",
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.3"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
   "homepage": ".",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.1",
-    "@types/react": "^17.0.38",
-    "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-jss": "^10.9.0",
@@ -32,6 +30,9 @@
     "tmi.js": "^1.8.5"
   },
   "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.10",
+    "@types/react-redux": "^7.1.25",
     "@types/tmi.js": "^1.8.2",
     "gh-pages": "^3.2.3",
     "html-webpack-plugin": "^5.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "jsx": "react",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   }


### PR DESCRIPTION
I was seeing typescript errors with module resolution on node 19. Updating the typescript version to after 4.7 and changing moduleResolution in the tsconfig fixes this.

Also moved type dependencies to devDependencies.